### PR TITLE
Ibexa org changes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {},
     "extra": {
         "branch-alias": {
-            "dev-main": "0.1.x-dev"
+            "dev-main": "0.2.x-dev"
         }
     }
 }

--- a/docker/Dockerfile-solr
+++ b/docker/Dockerfile-solr
@@ -1,7 +1,7 @@
 FROM solr:6-alpine
 
 # Copy solr config from the version used by eZ Platform
-COPY vendor/ezsystems/ezplatform-solr-search-engine/lib/Resources/config/solr/ /opt/solr/server/tmp
+COPY vendor/ibexa/solr/src/lib/Resources/config/solr/ /opt/solr/server/tmp
 
 # Prepare config
 RUN mkdir -p /opt/solr/server/ez/template \

--- a/docker/Dockerfile-varnish
+++ b/docker/Dockerfile-varnish
@@ -45,7 +45,7 @@ RUN set -xe \
         && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false $buildDeps \
         && rm -rf /var/lib/apt/lists/*
 
-COPY vendor/ezsystems/ezplatform-http-cache/docs/varnish/vcl/varnish5.vcl /etc/varnish/default.vcl
+COPY vendor/ibexa/http-cache/docs/varnish/vcl/varnish5.vcl /etc/varnish/default.vcl
 COPY doc/docker/entrypoint/varnish/parameters.vcl /etc/varnish/parameters.vcl
 COPY doc/docker/entrypoint/varnish/entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Varnish container fails to build on v4:
```
 Step 6/10 : COPY vendor/ezsystems/ezplatform-http-cache/docs/varnish/vcl/varnish5.vcl /etc/varnish/default.vcl
COPY failed: file not found in build context or excluded by .dockerignore: stat vendor/ezsystems/ezplatform-http-cache/docs/varnish/vcl/varnish5.vcl: file does not exist
Service 'varnish' failed to build : Build failed
```
(https://github.com/ibexa/oss/runs/4364725116?check_suite_focus=true)

The config files are in different places after the move to Ibexa:
1) https://github.com/ibexa/http-cache/tree/main/docs
2) https://github.com/ibexa/solr/tree/main/src/lib/Resources/config/solr

I've bumped main to `0.2` and created the 0.1 branch - 0.1 will be used for v3.3, 0.2 will be user for v4