### PR TITLE
Switched to Github for downloading varnish-modules

### DIFF
--- a/docker/Dockerfile-varnish
+++ b/docker/Dockerfile-varnish
@@ -35,6 +35,7 @@ RUN set -xe \
         && curl -A "Docker" -o /tmp/varnish-modules.tar.gz -D - -L -s https://github.com/varnish/varnish-modules/archive/refs/tags/${VARNISH_MODULES_VERSION}.tar.gz \
         && tar zxpf /tmp/varnish-modules.tar.gz -C /tmp/ \
         && cd /tmp/varnish-modules-${VARNISH_MODULES_VERSION} \
+        && ./bootstrap \
         && ./configure \
         && make \
         # && make check \

--- a/docker/Dockerfile-varnish
+++ b/docker/Dockerfile-varnish
@@ -32,7 +32,7 @@ RUN set -xe \
         && apt-get install -q -y --allow-unauthenticated --no-install-recommends varnish $buildDeps \
         \
     # Install varnish modules
-        && curl -A "Docker" -o /tmp/varnish-modules.tar.gz -D - -L -s https://download.varnish-software.com/varnish-modules/varnish-modules-${VARNISH_MODULES_VERSION}.tar.gz \
+        && curl -A "Docker" -o /tmp/varnish-modules.tar.gz -D - -L -s https://github.com/varnish/varnish-modules/archive/refs/tags/${VARNISH_MODULES_VERSION}.tar.gz \
         && tar zxpf /tmp/varnish-modules.tar.gz -C /tmp/ \
         && cd /tmp/varnish-modules-${VARNISH_MODULES_VERSION} \
         && ./configure \


### PR DESCRIPTION
`https://download.varnish-software.com` is down, but the file is still available in https://github.com/varnish/varnish-modules/releases/tag/0.15.0

This is a tag (not a release) which means we're building from source:
The `boostrap` step has to be added (from https://github.com/varnish/varnish-modules/tree/0.15.0#installation )

Tested in https://github.com/ibexa/oss/pull/53