### PR TITLE
Fixed SESSION_HANDLER_ID reference

### DIFF
--- a/docker/redis-session.yml
+++ b/docker/redis-session.yml
@@ -10,7 +10,7 @@ services:
     depends_on:
      - redis-session
     environment:
-     - SESSION_HANDLER_ID=ezplatform.core.session.handler.native_redis
+     - SESSION_HANDLER_ID=Ibexa\Bundle\Core\Session\Handler\NativeSessionHandler
      - SESSION_SAVE_PATH=tcp://redis-session:6379?weight=1
 
   redis-session:


### PR DESCRIPTION
Adjusting the ID after rebranding (`ezplatform.core.session.handler.native_redis` is no longer valid).

Instead the service is referenced by FQCN: https://github.com/ibexa/core/blob/main/src/bundle/Core/Session/Handler/NativeSessionHandler.php

I've verified locally that it works.