### PR TITLE
Selenium 4 upgrade

### DIFF
--- a/docker/selenium.yml
+++ b/docker/selenium.yml
@@ -6,17 +6,17 @@ services:
     image: ${SELENIUM_IMAGE}
     ports:
      - "9999:9999"
+     - "7900:7900"
      - "4444:4444"
      - "5900:5900"
     environment:
-     - SCREEN_WIDTH=1920
-     - SCREEN_HEIGHT=1080
-     - SCREEN_DEPTH=24
-     - VNC_NO_PASSWORD=1
+     - SE_VNC_NO_PASSWORD=1
+     - SE_NODE_MAX_SESSIONS=2
+     - SE_NODE_OVERRIDE_MAX_SESSIONS=true
     networks:
      - backend
     # Because of: https://github.com/elgalu/docker-selenium/issues/20
-    shm_size: '1gb'
+    shm_size: '2gb'
 
   app:
     depends_on:


### PR DESCRIPTION
JIRA: https://issues.ibexa.co/browse/IBX-4460

All PRs:
https://github.com/ibexa/recipes-dev/pull/60
https://github.com/ibexa/docker/pull/11
https://github.com/ibexa/version-comparison/pull/52
https://github.com/ibexa/admin-ui/pull/726
https://github.com/ibexa/behat/pull/59

Tested in https://github.com/ibexa/commerce/pull/227

Reference:
https://github.com/SeleniumHQ/docker-selenium

1) Port 7900 is mapped by default, to take advantage of https://github.com/SeleniumHQ/docker-selenium#using-your-browser-no-vnc-client-is-needed

It's a really cool feature 🤩 

2) `SE_VNC_NO_PASSWORD` is set to so we can forget about the `secret` password

3) The NODE_*_SESSIONS variables are needed to run 2 concurrent sessions in a container:
https://github.com/SeleniumHQ/docker-selenium#increasing-session-concurrency-per-container

Also I've bumped the shared memory size, as recommended in https://github.com/SeleniumHQ/docker-selenium#--shm-size2g

Running the container locally (on OSX):
```
docker run \
-e SE_VNC_NO_PASSWORD=1 \
-e SE_NODE_MAX_SESSIONS=2 \
-e SE_NODE_OVERRIDE_MAX_SESSIONS=true \
-p 7900:7900 \
-p 4444:4444 \
-p 5900:5900 \
--shm-size=2g -d \
--name=selenium4 \
--add-host="v4.ibexa:$(ipconfig getifaddr en0)" \
selenium/standalone-chrome:110.0-20230306
```