### PR TITLE
Allow specifying error_reporting using env variable

### DIFF
--- a/docker/base-dev.yml
+++ b/docker/base-dev.yml
@@ -14,6 +14,7 @@ services:
      - ENABLE_XDEBUG
      - EZPLATFORM_SITEACCESS
      - PHP_INI_ENV_memory_limit
+     - PHP_INI_ENV_error_reporting
      - APP_ENV=${APP_ENV-dev}
      - APP_DEBUG
      - APP_HTTP_CACHE


### PR DESCRIPTION
This PR makes it possible to set PHP's `error_reporting` using env variables. This is needed for https://github.com/ibexa/gh-workflows/pull/43 - and for the `Upgrade PHP and Symfony feature`

Tested in https://github.com/ezsystems/BehatBundle/pull/294