### PR TITLE
[Varnish] Upgraded Varnish to 6.0.12-1~bullseye

### DIFF
--- a/docker/Dockerfile-varnish
+++ b/docker/Dockerfile-varnish
@@ -21,7 +21,7 @@ RUN set -xe \
             pkg-config \
             python3-docutils \
             sphinx-common \
-            varnish-dev \
+            varnish-dev=6.0.12-1~bullseye \
         " \
     # Update apt and get dependencies
         && apt-get update -q -y \
@@ -29,7 +29,7 @@ RUN set -xe \
         \
     # Get official Varnish package
         && curl -s ${PACKAGECLOUD_URL} | bash \
-        && apt-get install -q -y --allow-unauthenticated --no-install-recommends varnish=6.0.11-1~bullseye $buildDeps \
+        && apt-get install -q -y --allow-unauthenticated --no-install-recommends varnish=6.0.12-1~bullseye $buildDeps \
         \
     # Install varnish modules
         && curl -A "Docker" -o /tmp/varnish-modules.tar.gz -D - -L -s https://github.com/varnish/varnish-modules/archive/refs/tags/${VARNISH_MODULES_VERSION}.tar.gz \


### PR DESCRIPTION
Example failure:
https://github.com/ibexa/commerce/actions/runs/6876564454/job/18702421458

```
11.43 The following packages have unmet dependencies:
11.47  varnish-dev : Depends: varnish (= 6.0.12-1~bullseye) but 6.0.11-1~bullseye is to be installed
11.48 E: Unable to correct problems, you have held broken packages.
```

A newer version is available for the `varnish` and `varnish-dev` packages:
- https://packagecloud.io/varnishcache/varnish60lts/packages/debian/bullseye/varnish_6.0.12-1~bullseye_amd64.deb?distro_version_id=207
- https://packagecloud.io/varnishcache/varnish60lts/packages/debian/bullseye/varnish-dev_6.0.12-1~bullseye_amd64.deb?distro_version_id=207

I'm doing two things:
1) Upgrading the version to the latest one
2) Pinning the varnish-dev version so it's consistent

Tested in https://github.com/ibexa/commerce/pull/470