### PR TITLE
Added sockets extension

### DIFF
--- a/php/Dockerfile-7.4
+++ b/php/Dockerfile-7.4
@@ -69,7 +69,7 @@ RUN set -xe \
     && docker-php-ext-configure pdo_mysql --with-pdo-mysql=mysqlnd \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-xpm=/usr/include/ --enable-gd-jis-conv \
-    && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql pdo_pgsql pgsql soap bcmath \
+    && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql pdo_pgsql pgsql soap bcmath sockets \
     && docker-php-ext-enable opcache \
     && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
     \

--- a/php/Dockerfile-8.0
+++ b/php/Dockerfile-8.0
@@ -75,7 +75,7 @@ RUN set -xe \
     && docker-php-ext-configure pdo_mysql --with-pdo-mysql=mysqlnd \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-xpm=/usr/include/ --enable-gd-jis-conv \
-    && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql pdo_pgsql pgsql soap bcmath \
+    && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql pdo_pgsql pgsql soap bcmath sockets \
     && docker-php-ext-enable opcache \
     && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
     \

--- a/php/Dockerfile-8.1
+++ b/php/Dockerfile-8.1
@@ -75,7 +75,7 @@ RUN set -xe \
     && docker-php-ext-configure pdo_mysql --with-pdo-mysql=mysqlnd \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-xpm=/usr/include/ --enable-gd-jis-conv \
-    && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql pdo_pgsql pgsql soap bcmath \
+    && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql pdo_pgsql pgsql soap bcmath sockets \
     && docker-php-ext-enable opcache \
     && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
     \

--- a/php/Dockerfile-8.2
+++ b/php/Dockerfile-8.2
@@ -75,7 +75,7 @@ RUN set -xe \
     && docker-php-ext-configure pdo_mysql --with-pdo-mysql=mysqlnd \
     && docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     && docker-php-ext-configure gd --with-freetype=/usr/include/ --with-jpeg=/usr/include/ --with-xpm=/usr/include/ --enable-gd-jis-conv \
-    && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql pdo_pgsql pgsql soap bcmath \
+    && docker-php-ext-install exif gd mbstring intl xsl zip mysqli pdo_mysql pdo_pgsql pgsql soap bcmath sockets \
     && docker-php-ext-enable opcache \
     && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
     \


### PR DESCRIPTION
It is needed by the new site-context package:
```
     - chrome-php/wrench[v1.5.0, ..., 1.6.x-dev] require ext-sockets * -> it is missing from your system. Install or enable PHP's sockets extension.
    - ibexa/site-context dev-IBX-7051-preview-btn-with-siteaccess requires chrome-php/chrome 1.10.x-dev -> satisfiable by chrome-php/chrome[1.10.x-dev].
    - chrome-php/chrome 1.10.x-dev requires chrome-php/wrench ^1.5 -> satisfiable by chrome-php/wrench[v1.5.0, 1.5.x-dev, 1.6.x-dev].
    - Root composer.json requires ibexa/site-context dev-IBX-7051-preview-btn-with-siteaccess as 4.6.x-dev -> satisfiable by ibexa/site-context[dev-IBX-7051-preview-btn-with-siteaccess].
```

Test failures are not related to this change (PHP 7.3 image was not changed)