### PR TITLE
[Percy] Increased page load timeout to 60

### DIFF
--- a/docker/percy.yml
+++ b/docker/percy.yml
@@ -9,6 +9,7 @@ services:
     environment:
      - PERCY_TOKEN
      - PERCY_BRANCH
+     - PERCY_PAGE_LOAD_TIMEOUT=60
     networks:
      - backend
     command: /bin/sh -c 'npm install -g @percy/cli && apk add chromium && PERCY_BROWSER_EXECUTABLE="/usr/bin/chromium-browser" npx percy exec:start'


### PR DESCRIPTION
Some snapshots in Percy are missing - they are not uploaded there, but there's nothing in the test's logs that indicate failure.

Locally I was able to get this error:
```
instance1-percy-1  | [percy] Encountered an error taking snapshot: DashboardContentOnTheFly
instance1-percy-1  | [percy] Error: Navigation failed: Timed out waiting for the page load event
```

This seems similar to this issue: https://github.com/percy/cli/issues/1421#issuecomment-1880510603

It would be best to investigate it deeper, but for now I think we can increase the timeout to 60 - it cannot harm and might be a temporary workaround

Percy reference: https://www.browserstack.com/docs/percy/get-started/set-env-var