### PR TITLE
Removed incompatible CKE Node versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,6 @@ jobs:
                     - "8.1"
                     - "8.2"
                 node:
-                    - "14"
-                    - "16"
                     - "18"
                 product-version:
                     - "~4.6.x-dev"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,9 +30,6 @@ jobs:
                 include:
                     - php: "7.3"
                       product-version: "~3.3.x-dev"
-                      node: "12"
-                    - php: "7.3"
-                      product-version: "~3.3.x-dev"
                       node: "14"
                     - php: "7.3"
                       product-version: "~3.3.x-dev"


### PR DESCRIPTION
v4.6: CKE5 v40 requires Node 18 at least.

v3.3: CKE4 / AE 1.5 requires Node 14 at least (ref. https://issues.ibexa.co/browse/IBX-5947).

Doc page for v3.3 states Node 14 minimum (https://doc.ibexa.co/en/latest/getting_started/requirements/#asset-manager).