### PR TITLE
Revert "[Percy] Increased page load timeout to 60 (#27)"

### DIFF
--- a/docker/percy.yml
+++ b/docker/percy.yml
@@ -9,7 +9,6 @@ services:
     environment:
      - PERCY_TOKEN
      - PERCY_BRANCH
-     - PERCY_PAGE_LOAD_TIMEOUT=60
     networks:
      - backend
     command: /bin/sh -c 'npm install -g @percy/cli && apk add chromium && PERCY_BROWSER_EXECUTABLE="/usr/bin/chromium-browser" npx percy exec:start'


### PR DESCRIPTION
This reverts commit c9618aceaaccfc90160bf3a792deac5c3231e8a4.

It looks like this breaks Percy build (both on CI and locally). I'm not sure why, but it's better to unblock us right now.