### PR TITLE
IBX-7818: Fixed direct access to index.php with long URL

### DIFF
--- a/php/Dockerfile-7.3
+++ b/php/Dockerfile-7.3
@@ -88,7 +88,7 @@ RUN set -xe \
     && docker-php-ext-enable igbinary \
     \
 # Install redis (manualy build in order to be able to enable igbinary)
-    && for i in $(seq 1 3); do pecl install -o --nobuild redis && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+    && for i in $(seq 1 3); do pecl install -o --nobuild "redis-6.0.2" && s=0 && break || s=$? && sleep 1; done; (exit $s) \
     && cd "$(pecl config-get temp_dir)/redis" \
     && phpize \
     && ./configure --enable-redis-igbinary \

--- a/php/Dockerfile-8.3
+++ b/php/Dockerfile-8.3
@@ -80,8 +80,21 @@ RUN set -xe \
     && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
     \
 # Install imagemagick
-    && for i in $(seq 1 3); do pecl install -o imagick && s=0 && break || s=$? && sleep 1; done; (exit $s) \
-    && docker-php-ext-enable imagick \
+#    && for i in $(seq 1 3); do pecl install -o imagick && s=0 && break || s=$? && sleep 1; done; (exit $s) \
+#    && docker-php-ext-enable imagick \
+
+# Imagick is installed from the archive because regular installation fails
+# See: https://github.com/Imagick/imagick/issues/643#issuecomment-1834361716
+    && curl -L -o /tmp/imagick.tar.gz https://github.com/Imagick/imagick/archive/refs/tags/3.7.0.tar.gz \
+    && tar --strip-components=1 -xf /tmp/imagick.tar.gz \
+    && phpize \
+    && ./configure \
+    && make \
+    && make install \
+    && echo "extension=imagick.so" > /usr/local/etc/php/conf.d/ext-imagick.ini \
+    && rm -rf /tmp/* \
+    # <<< End of Imagick installation
+
 # Install xdebug
     && for i in $(seq 1 3); do echo yes | pecl install -o "xdebug" && s=0 && break || s=$? && sleep 1; done; (exit $s) \
 # Install blackfire: https://blackfire.io/docs/integrations/docker

--- a/php/Dockerfile-8.3
+++ b/php/Dockerfile-8.3
@@ -79,10 +79,6 @@ RUN set -xe \
     && docker-php-ext-enable opcache \
     && cp /usr/src/php/php.ini-production ${PHP_INI_DIR}/php.ini \
     \
-# Install imagemagick
-#    && for i in $(seq 1 3); do pecl install -o imagick && s=0 && break || s=$? && sleep 1; done; (exit $s) \
-#    && docker-php-ext-enable imagick \
-
 # Imagick is installed from the archive because regular installation fails
 # See: https://github.com/Imagick/imagick/issues/643#issuecomment-1834361716
     && curl -L -o /tmp/imagick.tar.gz https://github.com/Imagick/imagick/archive/refs/tags/3.7.0.tar.gz \

--- a/templates/apache2/vhost.template
+++ b/templates/apache2/vhost.template
@@ -100,7 +100,7 @@
         RewriteRule ^/(css|js|fonts?)/.*\.(css|js|otf|eot|ttf|svg|woff) - [L]
 
         # Prevent access to website with direct usage of index.php in URL
-        RewriteRule ^/([^/]+/)?index\.php([/?#]|$) - [R=404,L]
+        RewriteRule ^/([^/]+/)*?index\.php([/?#]|$) - [R=404,L]
 
         RewriteRule .* /index.php
     </IfModule>

--- a/templates/nginx/ez_params.d/ez_rewrite_params
+++ b/templates/nginx/ez_params.d/ez_rewrite_params
@@ -19,7 +19,7 @@ rewrite "^/build/(.*)" "/build/$1" break;
 rewrite "^/assets/(.*)" "/assets/$1" break;
 
 # Prevent access to website with direct usage of index.php in URL
-if ($request_uri ~ "^/([^/]+/)?index\.php([/?#]|$)") {
+if ($request_uri ~ "^/([^/]+/)*?index\.php([/?#]|$)") {
     return 404;
 }
 


### PR DESCRIPTION
| :ticket: Issue | IBX-7818 |
|----------------|-----------|

#### Related PRs: 
- https://github.com/ibexa/post-install/pull/70


#### Description:
Applied improvement from IBX-7818 to web server templates which fixes direct access to index.php with long URL - https://github.com/ibexa/docker/pull/34/commits/e6ac11fd95f97551c0078ea6b8bac9a7fc0f6b82. New images have been already published and tested. Only images used in the current test matrix were updated.

#### For QA:
Imagick has a known and fixed but unreleased issue on PHP 8.3 (https://github.com/Imagick/imagick/issues/643#issuecomment-1834361716) - https://github.com/ibexa/docker/pull/34/commits/771f8eb682d82e400d3c4e10e0912c8356cdea63.

New redis 6.1 does not support PHP 7.3 (https://pecl.php.net/package/redis/6.1.0) - https://github.com/ibexa/docker/pull/34/commits/d5ea0f6625de38e3acecb5f50774feaefc003908.

Tested in https://github.com/ibexa/commerce/pull/1065.

Current state of tagged images (rebuilt Oct 8th): https://github.com/ibexa/docker/pkgs/container/docker%2Fphp/versions?filters%5Bversion_type%5D=tagged

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
