### PR TITLE
IBX-9916: Added Node 20 & 22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,12 +40,6 @@ jobs:
                       node: "18"
                     - php: "8.3"
                       product-version: "~5.0.x-dev"
-                      node: "18"
-                    - php: "8.3"
-                      product-version: "~5.0.x-dev"
-                      node: "20"
-                    - php: "8.3"
-                      product-version: "~5.0.x-dev"
                       node: "22"
 
         steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,6 @@ jobs:
                     - "8.3"
                 node:
                     - "18"
-                    - "20"
-                    - "22"
                 product-version:
                     - "~4.6.x-dev"
                 include:
@@ -38,6 +36,12 @@ jobs:
                     - php: "8.3"
                       product-version: "~3.3.x-dev"
                       node: "18"
+                    - php: "8.0"
+                      product-version: "~4.6.x-dev"
+                      node: "20"
+                    - php: "8.3"
+                      product-version: "~4.6.x-dev"
+                      node: "22"
                     - php: "8.3"
                       product-version: "~5.0.x-dev"
                       node: "22"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,6 +24,8 @@ jobs:
                     - "8.3"
                 node:
                     - "18"
+                    - "20"
+                    - "22"
                 product-version:
                     - "~4.6.x-dev"
                 include:
@@ -39,6 +41,12 @@ jobs:
                     - php: "8.3"
                       product-version: "~5.0.x-dev"
                       node: "18"
+                    - php: "8.3"
+                      product-version: "~5.0.x-dev"
+                      node: "20"
+                    - php: "8.3"
+                      product-version: "~5.0.x-dev"
+                      node: "22"
 
         steps:
             - uses: actions/checkout@v4

--- a/php/Dockerfile-node20
+++ b/php/Dockerfile-node20
@@ -1,0 +1,11 @@
+FROM ibexa_php:latest
+
+# Install Node.js and Yarn
+RUN apt-get update -q -y \
+    && apt-get install -q -y --no-install-recommends gnupg \ 
+    && curl -sL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && sudo apt-get update && sudo apt-get install yarn \
+    && rm -rf /var/lib/apt/lists/*

--- a/php/Dockerfile-node22
+++ b/php/Dockerfile-node22
@@ -1,0 +1,11 @@
+FROM ibexa_php:latest
+
+# Install Node.js and Yarn
+RUN apt-get update -q -y \
+    && apt-get install -q -y --no-install-recommends gnupg \ 
+    && curl -sL https://deb.nodesource.com/setup_22.x | bash - \
+    && apt-get install -y nodejs \
+    && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
+    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
+    && sudo apt-get update && sudo apt-get install yarn \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
| :ticket: Issue | IBX-9916 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/recipes-dev/pull/170


#### Description:
Added Node 20 & 22 to v4.6 and set Node 22 for v5.0.

CKEditor 45, introduced on v5.0, requires Node >=20.0.0, business decision is to require at least 22.

#### For QA:
New matrix will now be in terms of Node:

3.3:  14, 16, 18
4.6: 18, 20, 22
5.0: 22

My intention is to update test setups on DXP editions accordingly:
https://github.com/ibexa/oss/pull/221
https://github.com/ibexa/headless/pull/199
https://github.com/ibexa/experience/pull/528
https://github.com/ibexa/commerce/pull/1305

#### Documentation:
@mnocon adding you here as this will have to be reflected in docs eventually. 🙂 


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
