### PR TITLE
IBX-10495: [Backport] Included Elasticsearch 8 on CI

### DIFF
--- a/docker/elastic8.yml
+++ b/docker/elastic8.yml
@@ -1,0 +1,28 @@
+# Elastic config, to be appended after base-prod or base-dev, ..., but before selenium.yml
+#
+# NOTE: You'll need to manually run the command: php bin/console ibexa:elasticsearch:put-index-template.
+
+## WARNING!
+# This service is currently work in progress, is not tested by CI, and thus not guaranteed to work.
+# You are however more then welcome to try it out and help make it stable.
+
+services:
+    app:
+        depends_on:
+            - elasticsearch
+        environment:
+            - SEARCH_ENGINE=elasticsearch
+            - ELASTICSEARCH_DSN=elasticsearch:9200
+
+    elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.19.9
+        ports:
+            - "9200:9200"
+            - "9300:9300"
+        environment:
+            - discovery.type=single-node
+            - xpack.security.enabled=false
+            - xpack.security.http.ssl.enabled=false
+        networks:
+            - frontend
+            - backend

--- a/php/Dockerfile-node12
+++ b/php/Dockerfile-node12
@@ -3,12 +3,14 @@ FROM ibexa_php:latest
 # Install Node.js and Yarn
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
-        ca-certificates curl gnupg \
+        ca-certificates curl xz-utils \
     \
-    && curl -fsSL https://deb.nodesource.com/setup_12.x | bash - \
-    && apt-get install -y nodejs \
+    && curl -fsSL https://nodejs.org/dist/v12.22.12/node-v12.22.12-linux-x64.tar.xz \
+        | tar -xJ -C /usr/local --strip-components=1 \
     \
-    && corepack enable \
-    && corepack prepare yarn@stable --activate \
+    && node -v \
+    && npm -v \
+    \
+    && npm install -g yarn@1.22.19 \
     \
     && rm -rf /var/lib/apt/lists/*

--- a/php/Dockerfile-node12
+++ b/php/Dockerfile-node12
@@ -1,11 +1,14 @@
 FROM ibexa_php:latest
 
 # Install Node.js and Yarn
-RUN apt-get update -q -y \
-    && apt-get install -q -y --no-install-recommends gnupg \ 
-    && curl -sL https://deb.nodesource.com/setup_12.x | bash - \
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl gnupg \
+    \
+    && curl -fsSL https://deb.nodesource.com/setup_12.x | bash - \
     && apt-get install -y nodejs \
-    && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-    && sudo apt-get update && sudo apt-get install yarn \
+    \
+    && corepack enable \
+    && corepack prepare yarn@stable --activate \
+    \
     && rm -rf /var/lib/apt/lists/*

--- a/php/Dockerfile-node14
+++ b/php/Dockerfile-node14
@@ -3,12 +3,12 @@ FROM ibexa_php:latest
 # Install Node.js and Yarn
 RUN apt-get update -y \
     && apt-get install -y --no-install-recommends \
-        ca-certificates curl gnupg \
+        ca-certificates curl gnupg xz-utils \
     \
-    && curl -fsSL https://deb.nodesource.com/setup_14.x | bash - \
-    && apt-get install -y nodejs \
+    && curl -fsSL https://nodejs.org/dist/v14.21.3/node-v14.21.3-linux-x64.tar.xz \
+        | tar -xJ -C /usr/local --strip-components=1 \
     \
     && corepack enable \
-    && corepack prepare yarn@stable --activate \
+    && corepack prepare yarn@1.22.22 --activate \
     \
     && rm -rf /var/lib/apt/lists/*

--- a/php/Dockerfile-node14
+++ b/php/Dockerfile-node14
@@ -1,11 +1,14 @@
 FROM ibexa_php:latest
 
 # Install Node.js and Yarn
-RUN apt-get update -q -y \
-    && apt-get install -q -y --no-install-recommends gnupg \ 
-    && curl -sL https://deb.nodesource.com/setup_14.x | bash - \
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl gnupg \
+    \
+    && curl -fsSL https://deb.nodesource.com/setup_14.x | bash - \
     && apt-get install -y nodejs \
-    && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-    && sudo apt-get update && sudo apt-get install yarn \
+    \
+    && corepack enable \
+    && corepack prepare yarn@stable --activate \
+    \
     && rm -rf /var/lib/apt/lists/*

--- a/php/Dockerfile-node16
+++ b/php/Dockerfile-node16
@@ -8,7 +8,9 @@ RUN apt-get update -y \
     && curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
     && apt-get install -y nodejs \
     \
-    && corepack enable \
-    && corepack prepare yarn@stable --activate \
+    && npm install -g yarn@1.22.22 \
+    \
+    && node -v \
+    && yarn -v \
     \
     && rm -rf /var/lib/apt/lists/*

--- a/php/Dockerfile-node16
+++ b/php/Dockerfile-node16
@@ -1,11 +1,14 @@
 FROM ibexa_php:latest
 
 # Install Node.js and Yarn
-RUN apt-get update -q -y \
-    && apt-get install -q -y --no-install-recommends gnupg \ 
-    && curl -sL https://deb.nodesource.com/setup_16.x | bash - \
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl gnupg \
+    \
+    && curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
     && apt-get install -y nodejs \
-    && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-    && sudo apt-get update && sudo apt-get install yarn \
+    \
+    && corepack enable \
+    && corepack prepare yarn@stable --activate \
+    \
     && rm -rf /var/lib/apt/lists/*

--- a/php/Dockerfile-node18
+++ b/php/Dockerfile-node18
@@ -1,11 +1,14 @@
 FROM ibexa_php:latest
 
 # Install Node.js and Yarn
-RUN apt-get update -q -y \
-    && apt-get install -q -y --no-install-recommends gnupg \ 
-    && curl -sL https://deb.nodesource.com/setup_18.x | bash - \
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates curl gnupg \
+    \
+    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
     && apt-get install -y nodejs \
-    && curl -sL https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
-    && echo "deb https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-    && sudo apt-get update && sudo apt-get install yarn \
+    \
+    && corepack enable \
+    && corepack prepare yarn@stable --activate \
+    \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
| :ticket: Issue | IBX-10495 |
|----------------|-----------|


#### Related PRs: 
- https://github.com/ibexa/ci-scripts/pull/123


#### Description:
Backport of https://github.com/ibexa/docker/pull/54 to 4.6.

Added new file for Elasticsearch 8 (8.19.9).

Fixed Dockerfiles for Node (12, 14, 16, 18) to resolve issues with building and testing images on CI.

#### For QA:
Please see:
- https://github.com/ibexa/headless/pull/237
- https://github.com/ibexa/experience/pull/570
- https://github.com/ibexa/commerce/pull/1649

#### Documentation:
<!-- Optional. Replace this comment with details helpful for writing the doc: overview, code snippets for extensibility etc. -->


<!-- 
Before you click submit:
    - Test the solution manually
    - Provide automated test coverage
    - Confirm that target branch is set correctly
    - For new features, confirm that you have suitable access control and injection prevention
    - Run PHP CS Fixer for new PHP code (use $ composer fix-cs)
    - Run ESLint and Prettier for new JS/SCSS code (use $ yarn fix)
    - Ask for a review (ping @ibexa/php-dev or @ibexa/javascript-dev depending on the changes) 
--> 
