### PR TITLE
IBX-11778: Added new advisories to be able to build and publish PHP 7.4 images

### DIFF
--- a/bin/ci/test.sh
+++ b/bin/ci/test.sh
@@ -83,6 +83,11 @@ if [ "$REUSE_VOLUME" = "0" ]; then
           PKSA-8kk8-h2xr-h5nx
           PKSA-2rbx-bjdx-4d4d
           PKSA-fs5b-x5k4-1h39
+          PKSA-fbvq-z33h-r2np
+          PKSA-g9zw-qxh8-pq8w
+          PKSA-yd6k-t2gh-1m43
+          PKSA-1tmc-rt7x-12w6
+          PKSA-xx6c-6d96-db2w
         )
 
         PHP_VERSION=\"\$(php -r \"echo PHP_MAJOR_VERSION . \\\".\\\" . PHP_MINOR_VERSION;\")\"


### PR DESCRIPTION
| :ticket: Issue | IBX-11778 |
|----------------|-----------|

#### Related PRs:
- #60

#### Description:

Some advisories were added after the last build & publish and now [pre-publish test fails](https://github.com/ibexa/docker/actions/runs/27825668689/job/82349324312#step:4:179)

We need to rebuild images to update Composer to 2.10.1, adding support for new GitHub token format that now makes [REST functional tests CI fail](https://github.com/ibexa/http-cache/actions/runs/27820252956/job/82332038026#step:7:150).


#### For QA:

Review.
