### PR TITLE
IBX-11778: [GHA] Bumped versions of used GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
                 TEST_CMD: "vendor/bin/behat -v --profile=browser --suite=admin-ui --tags=@richtext --config=behat_ibexa_oss.yaml"
                 PRODUCT_VERSION: ${{ matrix.product-version }}
             - name: Log in to the Container registry
-              uses: docker/login-action@v3
+              uses: docker/login-action@v4
               with:
                 registry: ghcr.io
                 username: ${{ github.actor }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,7 +48,7 @@ jobs:
                       node: "22"
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v7
             - name: Build image
               run: bin/ci/build.sh ${{ matrix.php }} ${{ matrix.node }}
             - name: Test image


### PR DESCRIPTION
| :ticket: Issue | IBX-11778 |
|----------------|-----------|

#### Related PRs: 
- #61


#### Description:

- [x] [GHA] Updated `actions/checkout` to `v7`
- [x] [GHA] Updated `docker/login-action` to `v4`

#### For QA:

No QA required. Verify no Node.js 20 deprecation warnings in build logs.