### PR TITLE
IBX-12173: Added Varnish 9 Docker build

### DIFF
--- a/docker/Dockerfile-varnish9
+++ b/docker/Dockerfile-varnish9
@@ -1,0 +1,23 @@
+FROM varnish:9.0
+
+SHELL ["/bin/bash", "-c"]
+
+# set the user to root, and install build dependencies
+USER root
+RUN set -e && \
+    read -ra vmod_deps <<< "$VMOD_DEPS" && \
+    apt-get update && \
+    apt-get -y --no-install-recommends install "${vmod_deps[@]}" && \
+    install-vmod https://github.com/varnish/varnish-modules/releases/download/0.28.0/varnish-modules-0.28.0.tar.gz && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY vendor/ibexa/http-cache/docs/varnish/vcl/varnish9.vcl /etc/varnish/default.vcl
+COPY doc/docker/entrypoint/varnish/parameters.vcl /etc/varnish/parameters.vcl
+COPY doc/docker/entrypoint/varnish/entrypoint.sh /entrypoint.sh
+
+# entrypoint.sh writes into /etc/varnish at runtime (parameters.vcl.template), so hand the
+# directory to the non-root "varnish" user the base image already runs as by default
+RUN chown -R varnish:varnish /etc/varnish
+USER varnish
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/varnish9.yml
+++ b/docker/varnish9.yml
@@ -1,0 +1,43 @@
+version: '3.3'
+
+## WARNING!
+# This service is currently work in progress, is not tested by CI, and thus not guaranteed to work.
+# You are however more then welcome to try it out and help make it stable.
+
+services:
+  app:
+    environment:
+     - APP_HTTP_CACHE=0
+     # Never do this in production if the app container is accesible for the public as well
+     # See https://developers.ibexa.co/security-advisories/ezsa-2020-002-unauthorised-cache-purge-with-misconfigured-fastly
+     - TRUSTED_PROXIES=REMOTE_ADDR
+     - HTTPCACHE_PURGE_SERVER=http://varnish
+     - HTTPCACHE_PURGE_TYPE=varnish
+
+  varnish:
+    build:
+      context: ../../
+      dockerfile: doc/docker/Dockerfile-varnish9
+    ports:
+     - "8081:80"
+    environment:
+     - VARNISH_MALLOC_SIZE=256m
+    depends_on:
+     - web
+     - app
+    networks:
+     - frontend
+     - backend
+#    command: ["--acl-add", "app", "--debug-acl-add", "app"]
+    stdin_open: true
+    tty: true
+
+## DEBUG??
+# In need of debugging all request going to Varnish, use varnishlog, example:
+#   dockercompose exec varnish varnishlog -c -i ReqURL,ReqMethod -I ReqHeader:xkey
+#  Or more relevant only PURGE's with all info:
+#   docker compose exec varnish varnishlog -g request -q "ReqMethod eq 'PURGE'"
+#
+#  But before doing that check that http and not local purge client is set:
+#   docker compose exec app bin/console --env=dev debug:container ibexa.http_cache.purge_client_internal
+#

--- a/docker/varnish9.yml
+++ b/docker/varnish9.yml
@@ -8,7 +8,7 @@ services:
     environment:
      - APP_HTTP_CACHE=0
      # Never do this in production if the app container is accesible for the public as well
-     # See https://developers.ibexa.co/security-advisories/ezsa-2020-002-unauthorised-cache-purge-with-misconfigured-fastly for more details about how it could be abuse
+     # See https://developers.ibexa.co/security-advisories/ezsa-2020-002-unauthorised-cache-purge-with-misconfigured-fastly for more details about how it could be abused
      - TRUSTED_PROXIES=REMOTE_ADDR
      - HTTPCACHE_PURGE_SERVER=http://varnish
      - HTTPCACHE_PURGE_TYPE=varnish

--- a/docker/varnish9.yml
+++ b/docker/varnish9.yml
@@ -1,4 +1,3 @@
-version: '3.3'
 
 ## WARNING!
 # This service is currently work in progress, is not tested by CI, and thus not guaranteed to work.
@@ -9,7 +8,7 @@ services:
     environment:
      - APP_HTTP_CACHE=0
      # Never do this in production if the app container is accesible for the public as well
-     # See https://developers.ibexa.co/security-advisories/ezsa-2020-002-unauthorised-cache-purge-with-misconfigured-fastly
+     # See https://developers.ibexa.co/security-advisories/ezsa-2020-002-unauthorised-cache-purge-with-misconfigured-fastly for more details about how it could be abuse
      - TRUSTED_PROXIES=REMOTE_ADDR
      - HTTPCACHE_PURGE_SERVER=http://varnish
      - HTTPCACHE_PURGE_TYPE=varnish
@@ -34,7 +33,7 @@ services:
 
 ## DEBUG??
 # In need of debugging all request going to Varnish, use varnishlog, example:
-#   dockercompose exec varnish varnishlog -c -i ReqURL,ReqMethod -I ReqHeader:xkey
+#   docker compose exec varnish varnishlog -c -i ReqURL,ReqMethod -I ReqHeader:xkey
 #  Or more relevant only PURGE's with all info:
 #   docker compose exec varnish varnishlog -g request -q "ReqMethod eq 'PURGE'"
 #


### PR DESCRIPTION
| :ticket: Issue | [IBX-12173](https://ibexa.atlassian.net/browse/IBX-12173) |
|----------------|-----------|

> [!CAUTION]
>This PR from is from my own fork as I didn't have write permmission to ibexa/docker at the time. However, https://github.com/ibexa/http-cache/pull/84 needs this PR for it's CI to go green. I therefore had to add a `dependencies.json` to that PR. However, I cannot reference external repos in that file as that will cause GH rate limits. I therefore also pushed the branch for this docker PR to the ibexa repo too. Any changes to this PR needs to be pushed to that branch too. I don't expect any changes, that is why I didn't open it as a new PR


#### Related PRs:
- ibexa/http-cache#84 (source of the varnish9.vcl this build uses)
- https://github.com/ibexa/post-install/pull/107
- https://github.com/ibexa/cloud/pull/12
- https://github.com/ibexa/http-cache/pull/85

#### Description:
Adds `docker/Dockerfile-varnish9` and `docker/varnish9.yml`, Planning to remove varnish 7 in 6.0 branch as varnish7 is no longer maintained


#### For QA:
Use https://github.com/ibexa/docker/tree/IBX-12173_support_for_varnish9_50 when testing on 5.0

#### Documentation:


[IBX-12173]: https://ibexa.atlassian.net/browse/IBX-12173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ