### PR TITLE
IBX-11181: Added trusted_proxies ACL to Varnish setup

### DIFF
--- a/docker/entrypoint/varnish/entrypoint.sh
+++ b/docker/entrypoint/varnish/entrypoint.sh
@@ -4,6 +4,7 @@
 # [--acl-all-networks] - Add all container's network in the PURGE ACL.
 # [--acl-add ...] - Add a host or network segment to the PURGE ACL
 # [--debug-acl-add ...] - Add a host or network segment to the debuggers ACL
+# [--trusted-proxy-add ...] - Add a host or network segment to the trusted_proxies ACL
 
 function create_template_file
 {
@@ -64,6 +65,15 @@ function add_segment_to_debugger_acl
     sed -i -s "s|\(.*DEBUGGER.*\)|    $segment\n\1|" /etc/varnish/parameters.vcl
 }
 
+# $1 is segment, format 1.2.3.4/24 or myhostname
+function add_segment_to_trusted_proxies_acl
+{
+    segment=`format_segment $1`
+
+    echo "Adding network segment to varnish trusted_proxies : $segment"
+    sed -i -s "s|\(.*TRUSTED_PROXY.*\)|    $segment\n\1|" /etc/varnish/parameters.vcl
+}
+
 create_template_file
 
 while (( "$#" )); do
@@ -90,6 +100,15 @@ while (( "$#" )); do
             echo "Warning : --debug-acl-add parameter needs to be followed by a network segment, for instance \"--debug-add 10.0.1.0/24\""
         else
             add_segment_to_debugger_acl $new_network
+        fi
+    elif [ "$1" = "--trusted-proxy-add" ]; then
+        shift
+        new_network="$1"
+
+        if [ "$new_network" = "" ]; then
+            echo "Warning : --trusted-proxy-add parameter needs to be followed by a network segment, for instance \"--trusted-proxy-add 10.0.1.0/24\""
+        else
+            add_segment_to_trusted_proxies_acl $new_network
         fi
     else
         echo "Warning : Unrecognized parameter $1"

--- a/docker/entrypoint/varnish/parameters.vcl
+++ b/docker/entrypoint/varnish/parameters.vcl
@@ -18,3 +18,14 @@ acl debuggers {
     "172.16.0.0"/12;
 // DEBUGGER
 }
+
+// ACL for reverse proxies, TLS terminators and CDNs running in front of Varnish
+//
+// Only these are allowed to set the "X-Forwarded-*" and "Forwarded" headers, see vcl_recv.
+// Deliberately does not include the Docker network segment: nothing runs in front of Varnish in
+// this setup, so every incoming request is to be treated as coming straight from a client.
+// Extend with --trusted-proxy-add if you put something in front of it.
+acl trusted_proxies {
+    "127.0.0.1";
+// TRUSTED_PROXY
+}

--- a/docker/varnish-trusted-proxy.yml
+++ b/docker/varnish-trusted-proxy.yml
@@ -1,0 +1,19 @@
+# Overlay declaring the app container a trusted proxy.
+#
+# Apply it after any of the varnish compose files - varnish.yml, varnish7.yml, varnish9.yml - as
+# they all define the same "varnish" service and share the same entrypoint:
+#   -f doc/docker/base-dev.yml -f doc/docker/varnish.yml -f doc/docker/varnish-trusted-proxy.yml
+#
+# By default the trusted_proxies ACL in parameters.vcl holds only localhost, so Varnish strips the
+# X-Forwarded-* and Forwarded headers of every incoming request. Adding the app container makes
+# Varnish pass those headers through instead, which is what a TLS terminator, load balancer or CDN
+# running in front of Varnish relies on.
+#
+# The invalidators and debuggers flags are repeated here on purpose: Compose replaces "command"
+# wholesale, so listing only the new flag would drop the ones varnish.yml sets. Do not rely on the
+# 172.16.0.0/12 entry in parameters.vcl covering the app container - that only holds while Docker
+# allocates networks from its default pool.
+
+services:
+  varnish:
+    command: ["--acl-add", "app", "--debug-acl-add", "app", "--trusted-proxy-add", "app"]


### PR DESCRIPTION
| :ticket: Issue | IBX-11181 |
|----------------|-----------|

#### Related PRs:
- https://github.com/ibexa/core/pull/699
- https://github.com/ibexa/http-cache/pull/87
- https://github.com/ibexa/post-install/pull/108
- https://github.com/ibexa/cloud/pull/13

#### Description:
Supports the reverse proxy header filtering added in ibexa/http-cache#87.

`varnish5/6/7.vcl` now strip client supplied `X-Forwarded-*` and `Forwarded` headers unless the peer
is listed in a new `trusted_proxies` ACL. That ACL has to exist in `parameters.vcl`, since Varnish
resolves ACLs at VCL load time and otherwise refuses to load the configuration.

- `parameters.vcl` gains the `trusted_proxies` ACL, holding localhost only. The Docker network is
  deliberately left out: nothing runs in front of Varnish in this setup, so every incoming request
  is treated as coming straight from a client.
- `entrypoint.sh` gains `--trusted-proxy-add`, mirroring the existing `--acl-add` and
  `--debug-acl-add` flags.
- `varnish-trusted-proxy.yml` is a new overlay that adds the app container to that ACL, for the
  Behat suite. It applies on top of any of `varnish.yml`,
  `varnish7.yml` or `varnish9.yml`, since they all define the same `varnish` service.

